### PR TITLE
exluding slf4j-api because the version it pulls doesn't play nicely w/gra

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -5,7 +5,7 @@ grails.project.test.reports.dir = "target/test-reports"
 grails.project.dependency.resolution = {
     inherits "global"
     log "warn"
-    
+
     repositories {
         grailsHome()
         grailsCentral()
@@ -15,7 +15,7 @@ grails.project.dependency.resolution = {
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
         compile('org.hibernate:hibernate-core:3.3.1.GA', "org.quartz-scheduler:quartz:1.8.4") {
-            excludes 'ehcache', 'xml-apis', 'commons-logging'
+            excludes 'ehcache', 'xml-apis', 'commons-logging', 'slf4j-api'
         }
     }
 }


### PR DESCRIPTION
When we deployed our fork of the grails-quartz plugin as a war, the slf4j-api that grails-quartz pulled in to the project was not compatible with the version that was already present.  Fixed this by adding 'slf4j-api' to the excludes list in the grails-quartz BuildConfig.groovy file.
