### PR TITLE
Persistence interceptor

### DIFF
--- a/QuartzGrailsPlugin.groovy
+++ b/QuartzGrailsPlugin.groovy
@@ -54,7 +54,7 @@ but is made simpler by the coding by convention paradigm.
     def issueManagement = [system: "GitHub Issues", url: "http://github.com/nebolsin/grails-quartz/issues"]
     def scm = [url: "http://github.com/nebolsin/grails-quartz"]
 
-    def loadAfter = ['core', 'hibernate']
+    def loadAfter = ['core', 'hibernate', 'datasources']
     def watchedResources = [
             "file:./grails-app/jobs/**/*Job.groovy",
             "file:./plugins/*/grails-app/jobs/**/*Job.groovy"


### PR DESCRIPTION
To get the Grails Quartz plugin to play nicely with the additional datasources that we have defined using the Grails Datasources plugin, we refactored the SessionBinderJobListener to use the persistenceInterceptor to wrap Quartz jobs in a persistence context.  If you look at the Datasources implementation, you'll see that it has overridden the default persistenceInterceptor to include dataSourceNames for all of the datasources, not just the default.

In doing this, inspiration was taken from the Grails Executor plugin, which is using this pattern, and which seems to be the preferred way of doing this going forward.  

See these URLs for more info:

https://github.com/basejump/grails-executor
http://grails.1312388.n4.nabble.com/PersistenceContextInterceptor-usage-td3513733.html
